### PR TITLE
Check if state is undefined

### DIFF
--- a/src/operations/update.js
+++ b/src/operations/update.js
@@ -104,6 +104,7 @@ export function updateTree(walker, state, start=0) {
  * @return {State}
  */
 export function updateCounters(walker, state) {
+    if (!state) return state
     const counters = walker.enter(state)
 
     state = state.withMutations(state =>


### PR DESCRIPTION
It looks like in `src/operations/update.js` `node => updateCounters(walker, node)` is also performed when `node == undefined`
It occurs after `move_node` operation applier.
```
export function updateTree(walker, state, start=0) {
    // Why, oh why, is there no List#scan?
    return state.update('nodes', nodes => nodes.withMutations(nodes => {
        for (let index=start ; index < nodes.size ; ++index) {
            nodes = nodes.update(index, node => updateCounters(walker, node))
        }
        return nodes
    }))
}
```