### PR TITLE
Fix next value

### DIFF
--- a/src/slate/changes.js
+++ b/src/slate/changes.js
@@ -23,7 +23,7 @@ export function apply(counters, editor) {
             throw new Error("Unknown operation type: " + op.type)
         }
 
-        const next = ops.get(inx + 1, editor).value
+        const next = editor.value
 
         return applier(counters, op, next)
     }, counters)


### PR DESCRIPTION
After slate `0.45.0` there is no `value` in operations.